### PR TITLE
feat: type MATCHED/EXECUTION order events + order-response execution (taker delay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `orderEvent` EXECUTION frame (FAK/FOK terminal): `OmeOrderEvent` now models `type: 'EXECUTION'` with a `status` of `'FILLED' | 'PARTIALLY_FILLED' | 'KILLED'`. The `eventId` of an EXECUTION frame is the string `"terminal:<orderId>"`, so `OmeOrderEvent.eventId` now accepts `number | string`.
 - `orderEvent` MATCHED frame (pre-settlement per-fill): `SettlementOrderEvent` now models `type: 'MATCHED'`, adds `isEstimate?: boolean` (true on MATCHED, where fee fields are estimates) and `token?: 'YES' | 'NO'`. Maker side reports a `0` fee estimate; taker reports a real estimate.
+- `POST /orders` execution response: `OrderResponse` now carries an optional `execution` object (`Execution` / `ExecutionTotalsRaw`) exposing `settlementStatus` (plain string for forward-compat), `eligibleAt` for taker-delay markets, `feeRateBps` / `effectiveFeeBps`, and `totalsRaw`. The transform layer previously dropped this object from the create-order response; it is now passed through.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Limitless Exchange TypeScript SDK will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+### Added
+
+- `orderEvent` EXECUTION frame (FAK/FOK terminal): `OmeOrderEvent` now models `type: 'EXECUTION'` with a `status` of `'FILLED' | 'PARTIALLY_FILLED' | 'KILLED'`. The `eventId` of an EXECUTION frame is the string `"terminal:<orderId>"`, so `OmeOrderEvent.eventId` now accepts `number | string`.
+- `orderEvent` MATCHED frame (pre-settlement per-fill): `SettlementOrderEvent` now models `type: 'MATCHED'`, adds `isEstimate?: boolean` (true on MATCHED, where fee fields are estimates) and `token?: 'YES' | 'NO'`. Maker side reports a `0` fee estimate; taker reports a real estimate.
+
+### Changed
+
+- **BREAKING (types only):** `OmeOrderEvent.price` and `OmeOrderEvent.remainingSize` are now `number` instead of `string`. The runtime value never changed — every OME frame (PLACEMENT/UPDATE/CANCELLATION/EXECUTION) has always emitted these as JSON numbers; only the static type was wrong and is now corrected. Code that read them as strings (e.g. passed to `parseFloat`/`Number`, or string-compared) must be updated.
+- README, API-key v3 docs, and package metadata now target `v1.1.0`.
+
 ## [1.0.10]
 
 ### Added

--- a/docs/code-samples/websocket-events.ts
+++ b/docs/code-samples/websocket-events.ts
@@ -6,7 +6,7 @@
  */
 
 import { config } from 'dotenv';
-import { WebSocketClient } from '@limitless-exchange/sdk';
+import { WebSocketClient, OrderEvent } from '@limitless-exchange/sdk';
 
 config();
 
@@ -71,6 +71,19 @@ async function main() {
       console.log('\n🎯 Transaction Event:', JSON.stringify(data, null, 2));
     });
 
+    // Log order events (requires API key) — discriminate on source + type
+    wsClient.on('orderEvent', (data: OrderEvent) => {
+      if (data.source === 'OME' && data.type === 'EXECUTION') {
+        // FAK/FOK terminal frame: status is FILLED | PARTIALLY_FILLED | KILLED
+        console.log(`\n⚡ Order EXECUTION (${data.status}):`, JSON.stringify(data, null, 2));
+      } else if (data.source === 'SETTLEMENT' && data.type === 'MATCHED') {
+        // Pre-settlement per-fill frame: isEstimate is true, fee fields are estimates
+        console.log(`\n🤝 Order MATCHED (isEstimate=${data.isEstimate}):`, JSON.stringify(data, null, 2));
+      } else {
+        console.log('\n📨 Order Event:', JSON.stringify(data, null, 2));
+      }
+    });
+
     // Connect to WebSocket
     console.log('🔌 Connecting to WebSocket...');
     console.log(`   URL: ${WS_URL}\n`);
@@ -94,6 +107,11 @@ async function main() {
     console.log('📡 Subscribing to transactions...\n');
     await wsClient.subscribe('subscribe_transactions', {});
     console.log('✅ Subscribed to transactions\n');
+
+    // Subscribe to order events (requires API key)
+    console.log('📡 Subscribing to order events...\n');
+    await wsClient.subscribe('subscribe_order_events', {});
+    console.log('✅ Subscribed to order events\n');
 
     console.log('\n✅ All subscriptions active. Waiting for events...\n');
     console.log('💡 Now create/cancel orders to see events appear\n');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limitless-exchange/sdk",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "TypeScript SDK for Limitless Exchange CLOB and NegRisk trading",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/orders/client.ts
+++ b/src/orders/client.ts
@@ -384,6 +384,12 @@ export class OrderClient {
       }));
     }
 
+    // Pass through the execution summary (settlement status, fees, raw totals,
+    // and the taker-delay eligibleAt). Previously this object was dropped.
+    if (apiResponse.execution) {
+      cleanOrder.execution = apiResponse.execution;
+    }
+
     return cleanOrder;
   }
 

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -457,6 +457,119 @@ export interface OrderMatch {
 }
 
 /**
+ * Raw integer-string totals for an order execution.
+ *
+ * @remarks
+ * Every field is a decimal string holding a raw integer value (no scaling
+ * applied). `contracts*` are share/contract amounts; `usd*` are USDC amounts.
+ * Gross is the pre-fee total, fee is the fee taken, net is the post-fee total.
+ *
+ * @public
+ */
+export interface ExecutionTotalsRaw {
+  /**
+   * Fee taken in contracts, as a raw integer string
+   */
+  contractsFee: string;
+
+  /**
+   * Pre-fee contracts total, as a raw integer string
+   */
+  contractsGross: string;
+
+  /**
+   * Post-fee contracts total, as a raw integer string
+   */
+  contractsNet: string;
+
+  /**
+   * Fee taken in USDC, as a raw integer string
+   */
+  usdFee: string;
+
+  /**
+   * Pre-fee USDC total, as a raw integer string
+   */
+  usdGross: string;
+
+  /**
+   * Post-fee USDC total, as a raw integer string
+   */
+  usdNet: string;
+}
+
+/**
+ * Execution outcome summary returned with the create-order response.
+ *
+ * @remarks
+ * Carries the settlement/fee summary and the taker-delay outcome for the
+ * submitted order. Always returned by the server; modeled optional on the
+ * SDK response for back-compat safety.
+ *
+ * @public
+ */
+export interface Execution {
+  /**
+   * Echo of the caller-supplied client order id, when one was provided
+   */
+  clientOrderId?: string;
+
+  /**
+   * Effective fee actually applied, in integer basis points
+   */
+  effectiveFeeBps: number;
+
+  /**
+   * ISO-8601 timestamp at which the order is released to the matching engine.
+   *
+   * @remarks
+   * Present only when `settlementStatus === 'DELAYED'` — this is the
+   * taker-delay field. It is the moment the per-market taker delay expires
+   * and the held order is forwarded to the matching engine.
+   */
+  eligibleAt?: string;
+
+  /**
+   * Fee rate ceiling for the order, in integer basis points
+   */
+  feeRateBps: number;
+
+  /**
+   * Whether the order matched against any resting liquidity
+   */
+  matched: boolean;
+
+  /**
+   * Settlement state of the order.
+   *
+   * @remarks
+   * Kept as a plain string (not a closed union) for forward compatibility:
+   * the server adds new values over time, so a closed union would break on
+   * unknown values. Known values at time of writing:
+   * `'UNMATCHED' | 'MATCHED' | 'MINED' | 'CONFIRMED' | 'RETRYING' | 'FAILED' | 'DELAYED'`.
+   * `'DELAYED'` means the taker order was accepted but is held by a
+   * per-market taker delay before being released to the matching engine
+   * (see `eligibleAt`).
+   */
+  settlementStatus: string;
+
+  /**
+   * Raw integer-string totals for the execution
+   */
+  totalsRaw: ExecutionTotalsRaw;
+
+  /**
+   * Trade event id associated with the execution, when one exists
+   */
+  tradeEventId?: string;
+
+  /**
+   * Settlement transaction hash, or null when not yet mined
+   */
+  txHash?: string | null;
+}
+
+/**
  * Clean order creation response.
  *
  * @remarks
@@ -468,14 +581,23 @@ export interface OrderMatch {
  */
 export interface OrderResponse {
   /**
-   * Created order data
+   * Execution outcome summary (settlement status, fees, raw totals, and the
+   * taker-delay `eligibleAt` for delayed markets).
+   *
+   * @remarks
+   * Always returned by the server; optional here for back-compat safety.
    */
-  order: CreatedOrder;
+  execution?: Execution;
 
   /**
    * Matches if order was filled (FOK) or partially matched (GTC)
    */
   makerMatches?: OrderMatch[];
+
+  /**
+   * Created order data
+   */
+  order: CreatedOrder;
 }
 
 /**

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -173,16 +173,18 @@ export interface OraclePriceData {
  */
 export interface OmeOrderEvent {
   clientOrderId?: string;
-  eventId: number;
+  eventId: number | string;
   marketId: string;
   orderId: string;
-  price: string;
-  remainingSize: string;
+  price: number;
+  remainingSize: number;
   side: string;
   source: 'OME';
+  /** Present only on EXECUTION (FAK/FOK terminal) frames. */
+  status?: 'FILLED' | 'PARTIALLY_FILLED' | 'KILLED';
   timestamp: string;
   token: string;
-  type: 'PLACEMENT' | 'UPDATE' | 'CANCELLATION';
+  type: 'PLACEMENT' | 'UPDATE' | 'CANCELLATION' | 'EXECUTION';
   userId: number;
 }
 
@@ -210,6 +212,8 @@ export interface SettlementOrderEvent {
   eventId: string;
   feeAmountCollateral?: string;
   feeAmountContracts?: string;
+  /** True on pre-settlement MATCHED frames; fee fields are estimates. */
+  isEstimate?: boolean;
   makerMatches?: SettlementMakerMatch[];
   marketSlug?: string;
   orderId?: string;
@@ -219,10 +223,11 @@ export interface SettlementOrderEvent {
   takerAccount?: string;
   takerOrderId?: string;
   timestamp: Date | number | string;
+  token?: 'YES' | 'NO';
   tokenId?: string;
   tradeEventId?: string;
   txHash?: string;
-  type: 'MINED' | 'FAILED';
+  type: 'MINED' | 'FAILED' | 'MATCHED';
 }
 
 /**


### PR DESCRIPTION
## Order events (WebSocket)

Type the two `orderEvent` frames that ship in production but were untyped:

- `MATCHED` — pre-settlement per-fill (`source: 'SETTLEMENT'`, `type: 'MATCHED'`, `isEstimate`).
- `EXECUTION` — FAK/FOK terminal (`source: 'OME'`, `type: 'EXECUTION'`, `status: FILLED | PARTIALLY_FILLED | KILLED`).

Both widen the existing `OrderEvent` union members; discriminate on `source` + `type`.

**Breaking (types only):** `OmeOrderEvent.price` / `remainingSize` change `string` → `number`. The wire value was always a JSON number; only the static type is corrected, no runtime change.

## Order response `execution` (taker delay)

Model the `execution` object on the `POST /orders` response — previously dropped by the SDK. Exposes `settlementStatus` (plain string; includes `DELAYED` for taker-delay markets), `eligibleAt` (when a delayed order is released to the matching engine), fees, and raw totals. Additive, non-breaking.
