### PR TITLE
feat: self-trade prevention (stpPolicy request field + execution response object)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Limitless Exchange TypeScript SDK will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Self-trade prevention (STP):
+  - `StpPolicy` string union type (`'cancel_both' | 'cancel_maker' | 'cancel_taker'`).
+  - Optional `stpPolicy` request field on `OrderClient.createOrder()` and `DelegatedOrderService.createOrder()` params, threaded top-level on the request body (never inside the signed order). Omit to use the venue default (`cancel_maker`).
+- Order execution response:
+  - New `OrderExecution` and `OrderExecutionTotalsRaw` types.
+  - `OrderResponse.execution` is now surfaced (previously dropped by the response transform). Exposes `matched`, `settlementStatus` (plain string), fee figures, `reason`, `stpMakerCancels`, and raw decimal totals. Tolerant of responses that omit it.
+- WebSocket `OmeOrderEvent.reason` optional field — carries `STP_MAKER_CANCELLED` on STP-triggered `CANCELLATION` events.
+- Code sample `docs/code-samples/clob-stp-order.ts` demonstrating an STP order and reading the execution result.
+
 ## [1.0.10]
 
 ### Added

--- a/docs/code-samples/README.md
+++ b/docs/code-samples/README.md
@@ -297,6 +297,18 @@ Place Fill-And-Kill limit orders on CLOB markets.
 npx tsx docs/code-samples/clob-fak-order.ts
 ```
 
+#### Self-Trade Prevention (STP)
+
+**File**: `clob-stp-order.ts`
+
+Place a crossing order with an `stpPolicy` (`cancel_both` / `cancel_maker` / `cancel_taker`) and read the STP outcome from `response.execution` (`reason`, `stpMakerCancels`).
+
+**Run**:
+
+```bash
+npx tsx docs/code-samples/clob-stp-order.ts
+```
+
 ### NegRisk Markets
 
 #### FOK Orders

--- a/docs/code-samples/clob-stp-order.ts
+++ b/docs/code-samples/clob-stp-order.ts
@@ -1,0 +1,231 @@
+/**
+ * Self-Trade Prevention (STP) Order Example
+ *
+ * This example demonstrates how to:
+ * 1. Initialize SDK with API key authentication
+ * 2. Place a resting GTC order
+ * 3. Place a crossing order from the SAME account with an `stpPolicy`
+ * 4. Read the `execution` object on the response to see the STP outcome
+ *
+ * Self-trade prevention controls what happens when your incoming order would
+ * match against your own resting order:
+ *   - cancel_both  — cancel the resting maker order AND the incoming taker order
+ *   - cancel_maker — cancel the resting maker order, let the taker keep matching
+ *   - cancel_taker — cancel the incoming taker order, leave the maker resting
+ *
+ * Omit `stpPolicy` to use the venue default (`cancel_maker`).
+ *
+ * The `stpPolicy` field is sent top-level on the request body. It is never
+ * part of the signed EIP-712 order, so it does not affect the signature.
+ *
+ * Where the STP outcome shows up:
+ *   - HTTP response: `response.execution.reason` (e.g. `STP_TAKER_REJECTED`) and
+ *     `response.execution.stpMakerCancels` (UUIDs of canceled maker orders).
+ *   - WebSocket: a `CANCELLATION` order event carries `reason: STP_MAKER_CANCELLED`
+ *     for each maker order STP canceled. The taker reject is HTTP-only.
+ */
+
+import { config } from 'dotenv';
+import { ethers } from 'ethers';
+import {
+  HttpClient,
+  OrderClient,
+  MarketFetcher,
+  Side,
+  OrderType,
+  ConsoleLogger,
+} from '@limitless-exchange/sdk';
+
+// Load environment variables
+config();
+
+// Configuration constants
+const API_URL = process.env.API_URL || 'https://api.limitless.exchange';
+
+async function main() {
+  console.log('🚀 Self-Trade Prevention (STP) Order Example\n');
+
+  // Show configuration
+  console.log('⚙️  Configuration:');
+  console.log(`   API URL: ${API_URL}`);
+
+  // Validate API key
+  const apiKey = process.env.LIMITLESS_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'Please set LIMITLESS_API_KEY in .env file\n' +
+        'Get your API key from: https://limitless.exchange'
+    );
+  }
+
+  const marketSlug = process.env.MARKET_SLUG;
+  if (!marketSlug) {
+    throw new Error('Please set MARKET_SLUG in .env file');
+  }
+
+  // Validate private key
+  const privateKey = process.env.PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error('Please set PRIVATE_KEY in .env file');
+  }
+
+  const logger = new ConsoleLogger('info');
+
+  try {
+    // ===========================================
+    // STEP 1: Initialize HTTP Client and Wallet
+    // ===========================================
+    console.log('🔐 Step 1: Initializing HTTP client and wallet...');
+
+    const httpClient = new HttpClient({
+      baseURL: API_URL,
+      apiKey,
+      timeout: 30000,
+      logger,
+    });
+
+    const wallet = new ethers.Wallet(privateKey);
+
+    console.log(`   ✅ HTTP client initialized`);
+    console.log(`   ✅ Wallet initialized: ${wallet.address}\n`);
+
+    // ===========================================
+    // STEP 2: Fetch Market and Get Token ID
+    // ===========================================
+    console.log('📊 Step 2: Fetching market details...');
+
+    const marketFetcher = new MarketFetcher(httpClient);
+    const market = await marketFetcher.getMarket(marketSlug);
+
+    console.log(`   Market: ${market.title}`);
+    console.log(`   Type: ${market.marketType}\n`);
+
+    if (!market.tokens || !market.tokens.yes) {
+      throw new Error('Market has no YES token');
+    }
+
+    const tokenId = String(market.tokens.yes);
+    console.log(`   Token ID (YES): ${tokenId}\n`);
+
+    // ===========================================
+    // STEP 3: Create Order Client
+    // ===========================================
+    console.log('🔨 Step 3: Creating order client...');
+
+    const orderClient = new OrderClient({
+      httpClient,
+      wallet,
+    });
+
+    console.log('   ✅ Order client ready\n');
+
+    // ===========================================
+    // STEP 4: Place a Resting Maker Order
+    // ===========================================
+    console.log('📤 Step 4: Placing a resting BUY GTC order...');
+
+    const restingOrder = await orderClient.createOrder({
+      tokenId,
+      price: 0.6, // BUY at 0.60
+      size: 100,
+      side: Side.BUY,
+      orderType: OrderType.GTC,
+      marketSlug,
+    });
+
+    console.log('   ✅ Resting order placed');
+    console.log(`   Order ID: ${restingOrder.order.id}`);
+    if (restingOrder.execution) {
+      console.log(`   Settlement status: ${restingOrder.execution.settlementStatus}\n`);
+    }
+
+    // ===========================================
+    // STEP 5: Place a Crossing Order With STP
+    // ===========================================
+    console.log('📤 Step 5: Placing a crossing SELL order from the SAME account...');
+    console.log('   stpPolicy: cancel_taker (reject the incoming order, keep the maker resting)\n');
+
+    const crossingOrder = await orderClient.createOrder({
+      tokenId,
+      price: 0.6, // SELL at 0.60 — crosses our own resting BUY
+      size: 100,
+      side: Side.SELL,
+      orderType: OrderType.GTC,
+      marketSlug,
+      stpPolicy: 'cancel_taker',
+    });
+
+    console.log('   ✅ Crossing order submitted\n');
+
+    // ===========================================
+    // STEP 6: Read the Execution Result
+    // ===========================================
+    console.log('🔍 Step 6: Inspecting the execution result...');
+
+    const execution = crossingOrder.execution;
+    if (execution) {
+      console.log(`   Matched: ${execution.matched}`);
+      console.log(`   Settlement status: ${execution.settlementStatus}`);
+      console.log(`   Fee rate (bps): ${execution.feeRateBps}`);
+      console.log(`   Effective fee (bps): ${execution.effectiveFeeBps}`);
+
+      // STP taker signal is delivered on the HTTP response only.
+      if (execution.reason) {
+        console.log(`   Reason: ${execution.reason}`); // e.g. STP_TAKER_REJECTED
+      }
+
+      // UUIDs of maker orders that STP canceled (when stpPolicy cancels makers).
+      if (execution.stpMakerCancels && execution.stpMakerCancels.length > 0) {
+        console.log(`   STP canceled maker orders: ${execution.stpMakerCancels.join(', ')}`);
+      }
+
+      // Raw totals are decimal STRINGS — do not coerce.
+      console.log('   Totals (raw decimal strings):');
+      console.log(`     contractsGross: ${execution.totalsRaw.contractsGross}`);
+      console.log(`     contractsNet:   ${execution.totalsRaw.contractsNet}`);
+      console.log(`     usdGross:       ${execution.totalsRaw.usdGross}`);
+      console.log(`     usdNet:         ${execution.totalsRaw.usdNet}`);
+    } else {
+      console.log('   ⚠️  No execution object on the response (older API).');
+    }
+
+    console.log('\n📋 Full Crossing Order Response:');
+    console.log(JSON.stringify(crossingOrder, null, 2));
+
+    console.log('\n🎉 STP order example completed successfully!');
+    console.log('\n📚 Key points:');
+    console.log('   - stpPolicy is top-level and never affects the order signature');
+    console.log('   - cancel_both / cancel_maker / cancel_taker control the outcome');
+    console.log('   - execution.reason and execution.stpMakerCancels report the STP result');
+    console.log('   - On WebSocket, STP maker cancels arrive as CANCELLATION + reason=STP_MAKER_CANCELLED');
+  } catch (error) {
+    console.error('\n❌ Error occurred');
+
+    if (error && typeof error === 'object' && 'status' in error && 'data' in error) {
+      console.error('   Status:', (error as any).status);
+      console.error('   Message:', (error as any).message);
+      console.error('   URL:', (error as any).url);
+      console.error('   Method:', (error as any).method);
+      console.error('   Raw API Response:', JSON.stringify((error as any).data, null, 2));
+    } else if (error instanceof Error) {
+      console.error('   Message:', error.message);
+    } else {
+      console.error('   Unknown error:', error);
+    }
+
+    if (process.env.DEBUG === 'true' && error instanceof Error && error.stack) {
+      console.error('\n   Stack trace:');
+      console.error(error.stack);
+    }
+
+    process.exit(1);
+  }
+}
+
+// Run the example
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });

--- a/src/delegated-orders/service.ts
+++ b/src/delegated-orders/service.ts
@@ -68,6 +68,7 @@ export class DelegatedOrderService {
       ownerId: params.onBehalfOf,
       onBehalfOf: params.onBehalfOf,
       ...(postOnly !== undefined ? { postOnly } : {}),
+      // stpPolicy is sent top-level; do NOT add it to the signed order (would change the signature).
       ...(params.stpPolicy !== undefined ? { stpPolicy: params.stpPolicy } : {}),
     };
 

--- a/src/delegated-orders/service.ts
+++ b/src/delegated-orders/service.ts
@@ -68,6 +68,7 @@ export class DelegatedOrderService {
       ownerId: params.onBehalfOf,
       onBehalfOf: params.onBehalfOf,
       ...(postOnly !== undefined ? { postOnly } : {}),
+      ...(params.stpPolicy !== undefined ? { stpPolicy: params.stpPolicy } : {}),
     };
 
     this.logger.debug('Creating delegated order', {

--- a/src/orders/client.ts
+++ b/src/orders/client.ts
@@ -326,6 +326,7 @@ export class OrderClient {
       marketSlug: params.marketSlug,
       ownerId: userData.userId,
       ...(postOnly !== undefined ? { postOnly } : {}),
+      // stpPolicy is sent top-level; do NOT add it to the signed order (would change the signature).
       ...(params.stpPolicy !== undefined ? { stpPolicy: params.stpPolicy } : {}),
     };
 

--- a/src/orders/client.ts
+++ b/src/orders/client.ts
@@ -326,6 +326,7 @@ export class OrderClient {
       marketSlug: params.marketSlug,
       ownerId: userData.userId,
       ...(postOnly !== undefined ? { postOnly } : {}),
+      ...(params.stpPolicy !== undefined ? { stpPolicy: params.stpPolicy } : {}),
     };
 
     // Step 4: Submit to API
@@ -382,6 +383,12 @@ export class OrderClient {
         matchedSize: match.matchedSize,
         orderId: match.orderId,
       }));
+    }
+
+    // Pass execution through untouched. Present on current API responses;
+    // tolerated as missing on older API versions or hand-built responses.
+    if (apiResponse.execution !== undefined && apiResponse.execution !== null) {
+      cleanOrder.execution = apiResponse.execution;
     }
 
     return cleanOrder;

--- a/src/types/delegated-orders.ts
+++ b/src/types/delegated-orders.ts
@@ -1,4 +1,4 @@
-import type { OrderArgs, OrderResponse, OrderType, SignatureType, Side } from './orders';
+import type { OrderArgs, OrderResponse, OrderType, SignatureType, Side, StpPolicy } from './orders';
 
 /**
  * Delegated-order creation parameters.
@@ -10,6 +10,11 @@ export interface CreateDelegatedOrderParams {
   onBehalfOf: number;
   feeRateBps?: number;
   args: OrderArgs;
+  /**
+   * Self-trade prevention policy. Omit to use the venue default (`cancel_maker`).
+   * Sent top-level on the request body, never inside the signed order.
+   */
+  stpPolicy?: StpPolicy;
 }
 
 /**
@@ -44,6 +49,10 @@ export interface CreateDelegatedOrderRequest {
   ownerId: number;
   onBehalfOf?: number;
   postOnly?: boolean;
+  /**
+   * Self-trade prevention policy. Top-level, never part of the signed order.
+   */
+  stpPolicy?: StpPolicy;
 }
 
 /**

--- a/src/types/delegated-orders.ts
+++ b/src/types/delegated-orders.ts
@@ -11,8 +11,8 @@ export interface CreateDelegatedOrderParams {
   feeRateBps?: number;
   args: OrderArgs;
   /**
-   * Self-trade prevention policy. Omit to use the venue default (`cancel_maker`).
-   * Sent top-level on the request body, never inside the signed order.
+   * Optional self-trade-prevention policy. Omit to use the server default
+   * (`cancel_maker`).
    */
   stpPolicy?: StpPolicy;
 }
@@ -50,7 +50,8 @@ export interface CreateDelegatedOrderRequest {
   onBehalfOf?: number;
   postOnly?: boolean;
   /**
-   * Self-trade prevention policy. Top-level, never part of the signed order.
+   * Optional self-trade-prevention policy. Omit to use the server default
+   * (`cancel_maker`).
    */
   stpPolicy?: StpPolicy;
 }

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -26,18 +26,14 @@ export enum OrderType {
 }
 
 /**
- * Self-trade prevention policy.
+ * Self-trade-prevention policy: what happens when an order would match the
+ * same account's own resting orders.
  *
  * @remarks
- * Tells the matching engine what to do when an order would match against
- * another order owned by the same account.
- *
- * - `cancel_both` — cancel the resting maker order and the incoming taker order.
- * - `cancel_maker` — cancel the resting maker order, let the taker continue matching.
- * - `cancel_taker` — cancel the incoming taker order, leave the resting maker order.
- *
- * Omit to use the venue default (`cancel_maker`). Sent top-level on the request
- * body, never inside the signed order.
+ * - `cancel_maker` (default) — cancel the resting maker order, let the incoming
+ *   order continue matching.
+ * - `cancel_taker` — reject the incoming order, leave the resting maker order.
+ * - `cancel_both` — cancel both the resting maker order and the incoming order.
  *
  * @public
  */
@@ -90,12 +86,8 @@ export interface BaseOrderArgs {
   taker?: string;
 
   /**
-   * Self-trade prevention policy.
-   *
-   * @remarks
-   * Controls what happens if this order would match against another order
-   * owned by the same account. Omit to use the venue default (`cancel_maker`).
-   * Sent top-level on the request body, never inside the signed order.
+   * Optional self-trade-prevention policy. Omit to use the server default
+   * (`cancel_maker`).
    */
   stpPolicy?: StpPolicy;
 }
@@ -349,11 +341,8 @@ export interface NewOrderPayload {
   postOnly?: boolean;
 
   /**
-   * Self-trade prevention policy.
-   *
-   * @remarks
-   * Top-level field, sibling of `orderType`/`marketSlug`. Never part of the
-   * signed `order` struct. Omit to use the venue default (`cancel_maker`).
+   * Optional self-trade-prevention policy. Omit to use the server default
+   * (`cancel_maker`).
    */
   stpPolicy?: StpPolicy;
 }

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -26,6 +26,24 @@ export enum OrderType {
 }
 
 /**
+ * Self-trade prevention policy.
+ *
+ * @remarks
+ * Tells the matching engine what to do when an order would match against
+ * another order owned by the same account.
+ *
+ * - `cancel_both` — cancel the resting maker order and the incoming taker order.
+ * - `cancel_maker` — cancel the resting maker order, let the taker continue matching.
+ * - `cancel_taker` — cancel the incoming taker order, leave the resting maker order.
+ *
+ * Omit to use the venue default (`cancel_maker`). Sent top-level on the request
+ * body, never inside the signed order.
+ *
+ * @public
+ */
+export type StpPolicy = 'cancel_both' | 'cancel_maker' | 'cancel_taker';
+
+/**
  * Signature type enum.
  * @public
  */
@@ -70,6 +88,16 @@ export interface BaseOrderArgs {
    * @defaultValue '0x0000000000000000000000000000000000000000'
    */
   taker?: string;
+
+  /**
+   * Self-trade prevention policy.
+   *
+   * @remarks
+   * Controls what happens if this order would match against another order
+   * owned by the same account. Omit to use the venue default (`cancel_maker`).
+   * Sent top-level on the request body, never inside the signed order.
+   */
+  stpPolicy?: StpPolicy;
 }
 
 /**
@@ -319,6 +347,15 @@ export interface NewOrderPayload {
    * Supported only for GTC orders.
    */
   postOnly?: boolean;
+
+  /**
+   * Self-trade prevention policy.
+   *
+   * @remarks
+   * Top-level field, sibling of `orderType`/`marketSlug`. Never part of the
+   * signed `order` struct. Omit to use the venue default (`cancel_maker`).
+   */
+  stpPolicy?: StpPolicy;
 }
 
 /**
@@ -457,6 +494,106 @@ export interface OrderMatch {
 }
 
 /**
+ * Raw decimal totals for an order execution.
+ *
+ * @remarks
+ * All six fields are decimal strings, not numbers. Do not coerce them — they
+ * may carry more precision than IEEE-754 can represent.
+ *
+ * @public
+ */
+export interface OrderExecutionTotalsRaw {
+  /** Gross contracts (decimal string) */
+  contractsGross: string;
+  /** Contracts taken as fee (decimal string) */
+  contractsFee: string;
+  /** Net contracts after fee (decimal string) */
+  contractsNet: string;
+  /** Gross USD value (decimal string) */
+  usdGross: string;
+  /** USD taken as fee (decimal string) */
+  usdFee: string;
+  /** Net USD value after fee (decimal string) */
+  usdNet: string;
+}
+
+/**
+ * Execution result for a created order.
+ *
+ * @remarks
+ * Returned alongside the order on every create-order response. Surfaces the
+ * settlement status, fee figures, and self-trade-prevention outcome.
+ *
+ * `feeRateBps` and `effectiveFeeBps` are numbers. `totalsRaw.*` and
+ * `stpMakerCancels[]` are strings — do not coerce.
+ *
+ * @public
+ */
+export interface OrderExecution {
+  /**
+   * True if the order matched against resting liquidity.
+   */
+  matched: boolean;
+
+  /**
+   * Settlement status as a plain string.
+   *
+   * @remarks
+   * Known values: `DELAYED`, `UNMATCHED`, `CANCELED`, `MATCHED`, `MINED`,
+   * `CONFIRMED`, `RETRYING`, `FAILED`. Modeled as a string, not an enum, so new
+   * server-side values do not break deserialization.
+   */
+  settlementStatus: string;
+
+  /**
+   * Trade event id (uuid) when a fill occurred.
+   */
+  tradeEventId?: string;
+
+  /**
+   * Settlement transaction hash, or null before it is known.
+   */
+  txHash?: string | null;
+
+  /**
+   * Echo of the client-supplied order id, when one was sent.
+   */
+  clientOrderId?: string;
+
+  /**
+   * ISO timestamp at which a DELAYED order becomes eligible. DELAYED only.
+   */
+  eligibleAt?: string;
+
+  /**
+   * Free-form reason string. Carries the self-trade-prevention taker signal,
+   * e.g. `STP_TAKER_REJECTED`. HTTP response only.
+   */
+  reason?: string;
+
+  /**
+   * UUIDs of maker orders canceled by self-trade prevention. Present only when
+   * at least one maker order was canceled.
+   */
+  stpMakerCancels?: string[];
+
+  /**
+   * Configured fee rate in basis points (number).
+   */
+  feeRateBps: number;
+
+  /**
+   * Effective fee rate in basis points after rebates/overrides (number).
+   */
+  effectiveFeeBps: number;
+
+  /**
+   * Raw decimal totals (all fields are strings).
+   */
+  totalsRaw: OrderExecutionTotalsRaw;
+}
+
+/**
  * Clean order creation response.
  *
  * @remarks
@@ -476,6 +613,15 @@ export interface OrderResponse {
    * Matches if order was filled (FOK) or partially matched (GTC)
    */
   makerMatches?: OrderMatch[];
+
+  /**
+   * Execution result for this order.
+   *
+   * @remarks
+   * Present on every response from a current API. Optional here for tolerance
+   * against older API versions and hand-built responses that omit it.
+   */
+  execution?: OrderExecution;
 }
 
 /**

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -184,6 +184,12 @@ export interface OmeOrderEvent {
   token: string;
   type: 'PLACEMENT' | 'UPDATE' | 'CANCELLATION';
   userId: number;
+  /**
+   * Optional cancellation reason. On a `CANCELLATION` triggered by self-trade
+   * prevention, this carries `STP_MAKER_CANCELLED`. An STP-rejected taker is
+   * reported on the HTTP response only, not here.
+   */
+  reason?: string;
 }
 
 /**

--- a/tests/delegated-orders/service.test.ts
+++ b/tests/delegated-orders/service.test.ts
@@ -48,6 +48,74 @@ describe('DelegatedOrderService', () => {
     expect((httpClient as any).delete).toHaveBeenCalledWith('/orders/all/market-slug?onBehalfOf=326');
   });
 
+  it('threads stpPolicy top-level on the delegated payload and surfaces execution', async () => {
+    const execution = {
+      matched: false,
+      settlementStatus: 'CANCELED',
+      reason: 'STP_TAKER_REJECTED',
+      feeRateBps: 300,
+      effectiveFeeBps: 0,
+      totalsRaw: {
+        contractsGross: '0',
+        contractsFee: '0',
+        contractsNet: '0',
+        usdGross: '0',
+        usdFee: '0',
+        usdNet: '0',
+      },
+    };
+    const httpClient = {
+      requireAuth: vi.fn(),
+      post: vi.fn().mockResolvedValue({ order: { id: 'delegated-stp' }, execution }),
+    } as unknown as HttpClient;
+
+    const service = new DelegatedOrderService(httpClient);
+
+    const response = await service.createOrder({
+      marketSlug: 'test-market',
+      orderType: OrderType.GTC,
+      onBehalfOf: 326,
+      stpPolicy: 'cancel_taker',
+      args: {
+        tokenId: '123',
+        side: Side.BUY,
+        price: 0.55,
+        size: 10,
+      },
+    });
+
+    const [, payload] = (httpClient as any).post.mock.calls[0];
+    expect(payload.stpPolicy).toBe('cancel_taker');
+    expect('stpPolicy' in payload.order).toBe(false);
+
+    // Delegated path returns the raw response, so execution is surfaced as-is.
+    expect((response as any).execution).toEqual(execution);
+  });
+
+  it('omits stpPolicy from the delegated payload when unset', async () => {
+    const httpClient = {
+      requireAuth: vi.fn(),
+      post: vi.fn().mockResolvedValue({ order: { id: 'delegated-no-stp' } }),
+    } as unknown as HttpClient;
+
+    const service = new DelegatedOrderService(httpClient);
+
+    await service.createOrder({
+      marketSlug: 'test-market',
+      orderType: OrderType.GTC,
+      onBehalfOf: 326,
+      args: {
+        tokenId: '123',
+        side: Side.BUY,
+        price: 0.55,
+        size: 10,
+      },
+    });
+
+    const [, payload] = (httpClient as any).post.mock.calls[0];
+    expect('stpPolicy' in payload).toBe(false);
+  });
+
   it('omits postOnly for FAK delegated orders before submitting to the API', async () => {
     const httpClient = {
       requireAuth: vi.fn(),

--- a/tests/orders/client.test.ts
+++ b/tests/orders/client.test.ts
@@ -126,6 +126,250 @@ describe('OrderClient', () => {
     ]);
   });
 
+  it('passes the execution object through transformOrderResponse untouched', () => {
+    const client = new OrderClient({
+      httpClient: {} as any,
+      wallet: {
+        address: '0x0000000000000000000000000000000000000001',
+      } as any,
+    });
+
+    const execution = {
+      matched: true,
+      settlementStatus: 'MATCHED',
+      tradeEventId: '2c92ce01-e59b-4966-9d3f-a03bdb85e3eb',
+      txHash: null,
+      reason: 'STP_TAKER_REJECTED',
+      stpMakerCancels: ['11111111-1111-1111-1111-111111111111'],
+      feeRateBps: 300,
+      effectiveFeeBps: 0,
+      totalsRaw: {
+        contractsGross: '100.000000',
+        contractsFee: '0.000000',
+        contractsNet: '100.000000',
+        usdGross: '60.000000',
+        usdFee: '0.000000',
+        usdNet: '60.000000',
+      },
+    };
+
+    const transformed = (client as any).transformOrderResponse({
+      order: {
+        id: 'order-stp',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        makerAmount: '50',
+        takerAmount: '100',
+        expiration: '0',
+        signatureType: '0',
+        salt: '1742000000000000',
+        maker: '0x0000000000000000000000000000000000000001',
+        signer: '0x0000000000000000000000000000000000000001',
+        taker: '0x0000000000000000000000000000000000000000',
+        tokenId: '123',
+        side: '0',
+        feeRateBps: '300',
+        nonce: '0',
+        signature: '0xabc',
+        orderType: 'GTC',
+        price: '0.60',
+        marketId: '42',
+      },
+      execution,
+    });
+
+    // Pass-through: strings stay strings, numbers stay numbers, no coercion.
+    expect(transformed.execution).toEqual(execution);
+    expect(transformed.execution.feeRateBps).toBe(300);
+    expect(transformed.execution.totalsRaw.usdNet).toBe('60.000000');
+    expect(transformed.execution.stpMakerCancels).toEqual([
+      '11111111-1111-1111-1111-111111111111',
+    ]);
+  });
+
+  it('tolerates responses without an execution object (older API)', () => {
+    const client = new OrderClient({
+      httpClient: {} as any,
+      wallet: {
+        address: '0x0000000000000000000000000000000000000001',
+      } as any,
+    });
+
+    const transformed = (client as any).transformOrderResponse({
+      order: {
+        id: 'order-no-exec',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        makerAmount: '50',
+        takerAmount: '100',
+        expiration: '0',
+        signatureType: '0',
+        salt: '1742000000000000',
+        maker: '0x0000000000000000000000000000000000000001',
+        signer: '0x0000000000000000000000000000000000000001',
+        taker: '0x0000000000000000000000000000000000000000',
+        tokenId: '123',
+        side: '0',
+        feeRateBps: '300',
+        nonce: '0',
+        signature: '0xabc',
+        orderType: 'GTC',
+        price: '0.60',
+        marketId: '42',
+      },
+    });
+
+    expect(transformed.execution).toBeUndefined();
+  });
+
+  it('threads stpPolicy top-level into the order payload and never into the signed order', async () => {
+    const walletAddress = '0x0000000000000000000000000000000000000001';
+    const signature = `0x${'a'.repeat(130)}`;
+    const httpClient = {
+      post: vi.fn().mockResolvedValue({
+        order: {
+          id: 'order-stp',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          makerAmount: 5500000,
+          takerAmount: 10000000,
+          expiration: '0',
+          signatureType: 0,
+          salt: 123,
+          maker: walletAddress,
+          signer: walletAddress,
+          taker: '0x0000000000000000000000000000000000000000',
+          tokenId: '123',
+          side: 0,
+          feeRateBps: 300,
+          nonce: 0,
+          signature,
+          orderType: 'GTC',
+          price: 0.55,
+          marketId: 42,
+        },
+      }),
+    } as any;
+
+    const client = new OrderClient({
+      httpClient,
+      wallet: { address: walletAddress } as any,
+    });
+
+    (client as any).cachedUserData = { userId: 42, feeRateBps: 300 };
+    (client as any).orderBuilder = {
+      buildOrder: vi.fn().mockReturnValue({
+        salt: 123,
+        maker: walletAddress,
+        signer: walletAddress,
+        taker: '0x0000000000000000000000000000000000000000',
+        tokenId: '123',
+        makerAmount: 5500000,
+        takerAmount: 10000000,
+        expiration: '0',
+        nonce: 0,
+        feeRateBps: 300,
+        side: Side.BUY,
+        signatureType: 0,
+        price: 0.55,
+      }),
+    };
+    (client as any).orderSigner = {
+      signOrder: vi.fn().mockResolvedValue(signature),
+    };
+    (client as any).marketFetcher = {
+      getVenue: vi.fn().mockReturnValue({
+        exchange: '0x0000000000000000000000000000000000000002',
+        adapter: null,
+      }),
+    };
+
+    await client.createOrder({
+      tokenId: '123',
+      side: Side.BUY,
+      price: 0.55,
+      size: 10,
+      orderType: OrderType.GTC,
+      marketSlug: 'test-market',
+      stpPolicy: 'cancel_maker',
+    } as any);
+
+    const [, payload] = httpClient.post.mock.calls[0];
+    expect(payload.stpPolicy).toBe('cancel_maker');
+    expect('stpPolicy' in payload.order).toBe(false);
+  });
+
+  it('omits stpPolicy from the order payload when unset', async () => {
+    const walletAddress = '0x0000000000000000000000000000000000000001';
+    const signature = `0x${'a'.repeat(130)}`;
+    const httpClient = {
+      post: vi.fn().mockResolvedValue({
+        order: {
+          id: 'order-no-stp',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          makerAmount: 5500000,
+          takerAmount: 10000000,
+          expiration: '0',
+          signatureType: 0,
+          salt: 123,
+          maker: walletAddress,
+          signer: walletAddress,
+          taker: '0x0000000000000000000000000000000000000000',
+          tokenId: '123',
+          side: 0,
+          feeRateBps: 300,
+          nonce: 0,
+          signature,
+          orderType: 'GTC',
+          price: 0.55,
+          marketId: 42,
+        },
+      }),
+    } as any;
+
+    const client = new OrderClient({
+      httpClient,
+      wallet: { address: walletAddress } as any,
+    });
+
+    (client as any).cachedUserData = { userId: 42, feeRateBps: 300 };
+    (client as any).orderBuilder = {
+      buildOrder: vi.fn().mockReturnValue({
+        salt: 123,
+        maker: walletAddress,
+        signer: walletAddress,
+        taker: '0x0000000000000000000000000000000000000000',
+        tokenId: '123',
+        makerAmount: 5500000,
+        takerAmount: 10000000,
+        expiration: '0',
+        nonce: 0,
+        feeRateBps: 300,
+        side: Side.BUY,
+        signatureType: 0,
+        price: 0.55,
+      }),
+    };
+    (client as any).orderSigner = {
+      signOrder: vi.fn().mockResolvedValue(signature),
+    };
+    (client as any).marketFetcher = {
+      getVenue: vi.fn().mockReturnValue({
+        exchange: '0x0000000000000000000000000000000000000002',
+        adapter: null,
+      }),
+    };
+
+    await client.createOrder({
+      tokenId: '123',
+      side: Side.BUY,
+      price: 0.55,
+      size: 10,
+      orderType: OrderType.GTC,
+      marketSlug: 'test-market',
+    } as any);
+
+    const [, payload] = httpClient.post.mock.calls[0];
+    expect('stpPolicy' in payload).toBe(false);
+  });
+
   it('omits postOnly for FAK orders before submitting to the API', async () => {
     const walletAddress = '0x0000000000000000000000000000000000000001';
     const signature = `0x${'a'.repeat(130)}`;


### PR DESCRIPTION
## What

Adds self-trade prevention (STP) to the SDK.

- **Request:** optional top-level `stpPolicy` (`cancel_both` | `cancel_maker` | `cancel_taker`) on order creation — both the self-signed and delegated paths. Omitted by default (server defaults to `cancel_maker`). Sent top-level, **not** inside the signed EIP-712 order, so signatures are unchanged.
- **Response:** surfaces the `execution` object that `POST /orders` already returns and the SDK previously dropped — match flag, settlement status, fees, raw totals, and the STP signals (`reason`, `stpMakerCancels`). New `OrderExecution` type on `OrderResponse`.
- **WebSocket:** optional `reason` on the order-event frame (`STP_MAKER_CANCELLED` on a cancellation).

`settlementStatus` stays a plain string (no enum). Additive — existing callers are unaffected. Version is set at release, not here.

## Test

`pnpm typecheck` + `pnpm vitest run` (127 pass, incl. 6 new STP tests) + `pnpm build` — all green.
