### PR TITLE
feat(portfolio): add onBehalfOf to portfolio reads (x-on-behalf-of)

### DIFF
--- a/src/portfolio/fetcher.ts
+++ b/src/portfolio/fetcher.ts
@@ -100,6 +100,9 @@ export class PortfolioFetcher {
   /**
    * Gets raw portfolio positions response from API.
    *
+   * @param onBehalfOf - Optional sub-account profile id. Partner tokens with the
+   * `delegated_signing` scope can read a sub-account's positions via the
+   * `x-on-behalf-of` header. Omit to read the authenticated caller's own positions.
    * @returns Promise resolving to portfolio positions response with CLOB and AMM positions
    * @throws Error if API request fails or user is not authenticated
    *
@@ -111,12 +114,28 @@ export class PortfolioFetcher {
    * console.log(`Total points: ${response.accumulativePoints}`);
    * ```
    */
-  async getPositions(): Promise<PortfolioPositionsResponse> {
-    this.logger.debug('Fetching user positions');
+  /**
+   * Builds the request config for a delegated (partner on-behalf-of) read.
+   * Partners with the `delegated_signing` scope can read a sub-account's data by
+   * sending the `x-on-behalf-of` header. The HMAC signature covers only
+   * timestamp/method/path/body, so this extra header does not affect auth.
+   */
+  private onBehalfOfConfig(onBehalfOf?: number): { headers: Record<string, string> } | undefined {
+    if (onBehalfOf === undefined) return undefined;
+    if (!Number.isInteger(onBehalfOf) || onBehalfOf <= 0) {
+      throw new Error('onBehalfOf must be a positive integer');
+    }
+    return { headers: { 'x-on-behalf-of': String(onBehalfOf) } };
+  }
+
+  async getPositions(onBehalfOf?: number): Promise<PortfolioPositionsResponse> {
+    this.logger.debug('Fetching user positions', { onBehalfOf });
 
     try {
-      const response =
-        await this.httpClient.get<PortfolioPositionsResponse>('/portfolio/positions');
+      const response = await this.httpClient.get<PortfolioPositionsResponse>(
+        '/portfolio/positions',
+        this.onBehalfOfConfig(onBehalfOf)
+      );
 
       this.logger.info('Positions fetched successfully', {
         clobCount: response.clob?.length || 0,
@@ -144,8 +163,8 @@ export class PortfolioFetcher {
    * });
    * ```
    */
-  async getCLOBPositions(): Promise<CLOBPosition[]> {
-    const response = await this.getPositions();
+  async getCLOBPositions(onBehalfOf?: number): Promise<CLOBPosition[]> {
+    const response = await this.getPositions(onBehalfOf);
     return response.clob || [];
   }
 
@@ -163,8 +182,8 @@ export class PortfolioFetcher {
    * });
    * ```
    */
-  async getAMMPositions(): Promise<AMMPosition[]> {
-    const response = await this.getPositions();
+  async getAMMPositions(onBehalfOf?: number): Promise<AMMPosition[]> {
+    const response = await this.getPositions(onBehalfOf);
     return response.amm || [];
   }
 
@@ -175,6 +194,7 @@ export class PortfolioFetcher {
    *
    * @param cursor - Opaque cursor for pagination. Omit it or pass an empty string for the first page.
    * @param limit - Number of items per page
+   * @param onBehalfOf - Optional sub-account profile id (partner `delegated_signing` scope).
    * @returns Promise resolving to cursor-paginated history response
    * @throws Error if API request fails or user is not authenticated
    *
@@ -196,8 +216,12 @@ export class PortfolioFetcher {
    * }
    * ```
    */
-  async getUserHistory(cursor?: string, limit: number = 20): Promise<HistoryResponse> {
-    this.logger.debug('Fetching user history', { cursor, limit });
+  async getUserHistory(
+    cursor?: string,
+    limit: number = 20,
+    onBehalfOf?: number
+  ): Promise<HistoryResponse> {
+    this.logger.debug('Fetching user history', { cursor, limit, onBehalfOf });
 
     try {
       // Always send cursor=, using an empty value on the first page.
@@ -207,7 +231,8 @@ export class PortfolioFetcher {
       });
 
       const response = await this.httpClient.get<HistoryResponse>(
-        `/portfolio/history?${params.toString()}`
+        `/portfolio/history?${params.toString()}`,
+        this.onBehalfOfConfig(onBehalfOf)
       );
 
       this.logger.info('User history fetched successfully');

--- a/tests/portfolio/fetcher.test.ts
+++ b/tests/portfolio/fetcher.test.ts
@@ -73,6 +73,48 @@ describe('PortfolioFetcher', () => {
 
     await fetcher.getUserHistory('cursor-1', 5);
 
-    expect(httpClient.get).toHaveBeenCalledWith('/portfolio/history?cursor=cursor-1&limit=5');
+    expect(httpClient.get).toHaveBeenCalledWith('/portfolio/history?cursor=cursor-1&limit=5', undefined);
+  });
+
+  it('getPositions reads the caller by default (no on-behalf-of header)', async () => {
+    vi.mocked(httpClient.get).mockResolvedValue({ clob: [], amm: [] });
+
+    await fetcher.getPositions();
+
+    expect(httpClient.get).toHaveBeenCalledWith('/portfolio/positions', undefined);
+  });
+
+  it('getPositions sends x-on-behalf-of when a sub-account id is provided', async () => {
+    vi.mocked(httpClient.get).mockResolvedValue({ clob: [], amm: [] });
+
+    await fetcher.getPositions(123);
+
+    expect(httpClient.get).toHaveBeenCalledWith('/portfolio/positions', {
+      headers: { 'x-on-behalf-of': '123' },
+    });
+  });
+
+  it('getCLOBPositions forwards on-behalf-of to getPositions', async () => {
+    vi.mocked(httpClient.get).mockResolvedValue({ clob: [], amm: [] });
+
+    await fetcher.getCLOBPositions(123);
+
+    expect(httpClient.get).toHaveBeenCalledWith('/portfolio/positions', {
+      headers: { 'x-on-behalf-of': '123' },
+    });
+  });
+
+  it('getUserHistory sends x-on-behalf-of when provided', async () => {
+    vi.mocked(httpClient.get).mockResolvedValue({ data: [], nextCursor: null });
+
+    await fetcher.getUserHistory(undefined, 20, 123);
+
+    expect(httpClient.get).toHaveBeenCalledWith('/portfolio/history?cursor=&limit=20', {
+      headers: { 'x-on-behalf-of': '123' },
+    });
+  });
+
+  it.each([0, -1, 1.5])('rejects invalid on-behalf-of id %p', async (bad) => {
+    await expect(fetcher.getPositions(bad)).rejects.toThrow('onBehalfOf must be a positive integer');
   });
 });


### PR DESCRIPTION
## What

Adds an optional `onBehalfOf` argument to the portfolio **read** methods so a partner token with the `delegated_signing` scope can read a sub-account's data:

- `getPositions(onBehalfOf?)`
- `getCLOBPositions(onBehalfOf?)`
- `getAMMPositions(onBehalfOf?)`
- `getUserHistory(cursor?, limit?, onBehalfOf?)`

When provided, the request sends the `x-on-behalf-of: <profileId>` header. Omitted ⇒ unchanged (reads the authenticated caller).

## Why

`delegatedOrders` and `serverWallets` already support `onBehalfOf` for writes, but portfolio **reads** had no way to pass it — so a partner managing server-wallet sub-accounts (e.g. the Limitless MCP server) can place/cancel/withdraw on behalf of a sub-account but can't read that sub-account's positions or history. This closes that asymmetry.

## Safety

The HMAC signature is computed over `timestamp\nMETHOD\npath\nbody` only (see `api/hmac.ts`), so adding a request header does **not** affect auth. Invalid ids (`<= 0`, non-integer) throw before the request.

## Tests

`tests/portfolio/fetcher.test.ts`: header sent when id provided, no header by default, forwarding through `getCLOBPositions`, history variant, and rejection of invalid ids. Full suite green (128 tests).

## ⚠️ Needs dev validation before merge

I could not exercise this against a live backend. Please confirm on dev that `GET /portfolio/positions` and `GET /portfolio/history` honor `x-on-behalf-of` with a `delegated_signing`-scoped partner token (the backend route has `@AllowDelegation`, but I haven't run it end-to-end).

## Follow-up

The same gap exists in the Go, Rust, and Python SDKs. Suggest landing this TS version as the reference, then porting once the approach is confirmed on dev.
