### PR TITLE
feat: add cancel-replace order support

### DIFF
--- a/src/delegated-orders/service.ts
+++ b/src/delegated-orders/service.ts
@@ -5,8 +5,13 @@ import {
   type CancelResponse,
   type CreateDelegatedOrderParams,
   type CreateDelegatedOrderRequest,
+  type DelegatedCancelReplaceBatchParams,
+  type DelegatedCancelReplaceParams,
+  type DelegatedCancelReplaceReplacementParams,
+  type DelegatedCancelReplaceReplacementRequest,
   type DelegatedOrderResponse,
 } from '../types/delegated-orders';
+import type { CancelReplaceBatchResponse, CancelReplaceResponse } from '../types/orders';
 import { OrderType, SignatureType } from '../types/orders';
 import type { ILogger } from '../types/logger';
 import { NoOpLogger } from '../types/logger';
@@ -33,9 +38,10 @@ export class DelegatedOrderService {
       throw new Error('onBehalfOf must be a positive integer');
     }
 
-    const feeRateBps = params.feeRateBps && params.feeRateBps > 0
-      ? params.feeRateBps
-      : DEFAULT_DELEGATED_FEE_RATE_BPS;
+    const feeRateBps =
+      params.feeRateBps && params.feeRateBps > 0
+        ? params.feeRateBps
+        : DEFAULT_DELEGATED_FEE_RATE_BPS;
 
     const builder = new OrderBuilder(ZERO_ADDRESS, feeRateBps);
     const unsignedOrder = builder.buildOrder(params.args);
@@ -79,9 +85,79 @@ export class DelegatedOrderService {
     return this.httpClient.post<DelegatedOrderResponse>('/orders', payload);
   }
 
+  async cancelReplace(params: DelegatedCancelReplaceParams): Promise<CancelReplaceResponse> {
+    this.httpClient.requireAuth('cancelReplaceDelegatedOrder');
+    this.assertOnBehalfOf(params.onBehalfOf);
+    const payload = {
+      cancel: params.cancel,
+      replacement: this.buildCancelReplaceReplacement(params.replacement, params.onBehalfOf),
+      mode: params.mode,
+      onBehalfOf: params.onBehalfOf,
+    };
+    const body = JSON.stringify(payload);
+
+    return this.httpClient.post<CancelReplaceResponse>('/orders/cancel-replace', body, {
+      validateStatus: (status) => (status >= 200 && status < 300) || status === 409,
+    });
+  }
+
+  async cancelReplaceBatch(
+    params: DelegatedCancelReplaceBatchParams
+  ): Promise<CancelReplaceBatchResponse> {
+    this.httpClient.requireAuth('cancelReplaceDelegatedOrderBatch');
+    const operations = params.operations.map((operation) => {
+      this.assertOnBehalfOf(operation.onBehalfOf);
+      return {
+        cancel: operation.cancel,
+        replacement: this.buildCancelReplaceReplacement(
+          operation.replacement,
+          operation.onBehalfOf
+        ),
+        mode: operation.mode,
+        onBehalfOf: operation.onBehalfOf,
+      };
+    });
+    const body = JSON.stringify({ operations });
+
+    return this.httpClient.post<CancelReplaceBatchResponse>('/orders/cancel-replace/batch', body);
+  }
+
+  private buildCancelReplaceReplacement(
+    params: DelegatedCancelReplaceReplacementParams,
+    onBehalfOf: number
+  ): DelegatedCancelReplaceReplacementRequest {
+    const feeRateBps =
+      params.feeRateBps && params.feeRateBps > 0
+        ? params.feeRateBps
+        : DEFAULT_DELEGATED_FEE_RATE_BPS;
+    const unsignedOrder = new OrderBuilder(ZERO_ADDRESS, feeRateBps).buildOrder(params);
+    const postOnly =
+      params.orderType === OrderType.GTC && 'postOnly' in params ? params.postOnly : undefined;
+
+    return {
+      order: unsignedOrder,
+      orderType: params.orderType,
+      marketSlug: params.marketSlug,
+      ownerId: onBehalfOf,
+      ...(postOnly !== undefined ? { postOnly } : {}),
+      ...(params.clientOrderId !== undefined ? { clientOrderId: params.clientOrderId } : {}),
+      ...(params.timestamp !== undefined ? { timestamp: params.timestamp } : {}),
+      ...(params.recvWindow !== undefined ? { recvWindow: params.recvWindow } : {}),
+      ...(params.stpPolicy !== undefined ? { stpPolicy: params.stpPolicy } : {}),
+    };
+  }
+
+  private assertOnBehalfOf(onBehalfOf: number): void {
+    if (!Number.isInteger(onBehalfOf) || onBehalfOf <= 0) {
+      throw new Error('onBehalfOf must be a positive integer');
+    }
+  }
+
   async cancel(orderId: string): Promise<string> {
     this.httpClient.requireAuth('cancelDelegatedOrder');
-    const response = await this.httpClient.delete<CancelResponse>(`/orders/${encodeURIComponent(orderId)}`);
+    const response = await this.httpClient.delete<CancelResponse>(
+      `/orders/${encodeURIComponent(orderId)}`
+    );
     return response.message;
   }
 
@@ -92,14 +168,16 @@ export class DelegatedOrderService {
     }
 
     const response = await this.httpClient.delete<CancelResponse>(
-      `/orders/${encodeURIComponent(orderId)}?onBehalfOf=${onBehalfOf}`,
+      `/orders/${encodeURIComponent(orderId)}?onBehalfOf=${onBehalfOf}`
     );
     return response.message;
   }
 
   async cancelAll(marketSlug: string): Promise<string> {
     this.httpClient.requireAuth('cancelAllDelegatedOrders');
-    const response = await this.httpClient.delete<CancelResponse>(`/orders/all/${encodeURIComponent(marketSlug)}`);
+    const response = await this.httpClient.delete<CancelResponse>(
+      `/orders/all/${encodeURIComponent(marketSlug)}`
+    );
     return response.message;
   }
 
@@ -110,7 +188,7 @@ export class DelegatedOrderService {
     }
 
     const response = await this.httpClient.delete<CancelResponse>(
-      `/orders/all/${encodeURIComponent(marketSlug)}?onBehalfOf=${onBehalfOf}`,
+      `/orders/all/${encodeURIComponent(marketSlug)}?onBehalfOf=${onBehalfOf}`
     );
     return response.message;
   }

--- a/src/orders/client.ts
+++ b/src/orders/client.ts
@@ -7,6 +7,12 @@ import type { HttpClient } from '../api/http';
 import type { ILogger } from '../types/logger';
 import { NoOpLogger } from '../types/logger';
 import type {
+  CancelReplaceBatchParams,
+  CancelReplaceBatchResponse,
+  CancelReplaceParams,
+  CancelReplaceReplacementParams,
+  CancelReplaceReplacementRequest,
+  CancelReplaceResponse,
   NewOrderPayload,
   OrderResponse,
   OrderArgs,
@@ -311,9 +317,7 @@ export class OrderClient {
 
     // Step 3: Prepare payload for API
     const postOnly =
-      params.orderType === OrderType.GTC &&
-      'postOnly' in params &&
-      params.postOnly !== undefined
+      params.orderType === OrderType.GTC && 'postOnly' in params && params.postOnly !== undefined
         ? params.postOnly
         : undefined;
 
@@ -338,6 +342,66 @@ export class OrderClient {
 
     // Step 5: Transform API response to clean DTO
     return this.transformOrderResponse(apiResponse);
+  }
+
+  async cancelReplace(params: CancelReplaceParams): Promise<CancelReplaceResponse> {
+    const payload = {
+      cancel: params.cancel,
+      replacement: await this.buildCancelReplaceReplacement(params.replacement),
+      mode: params.mode,
+    };
+    const body = JSON.stringify(payload);
+
+    return this.httpClient.post<CancelReplaceResponse>('/orders/cancel-replace', body, {
+      validateStatus: (status) => (status >= 200 && status < 300) || status === 409,
+    });
+  }
+
+  async cancelReplaceBatch(params: CancelReplaceBatchParams): Promise<CancelReplaceBatchResponse> {
+    const operations = await Promise.all(
+      params.operations.map(async (operation) => ({
+        cancel: operation.cancel,
+        replacement: await this.buildCancelReplaceReplacement(operation.replacement),
+        mode: operation.mode,
+      }))
+    );
+    const body = JSON.stringify({ operations });
+
+    return this.httpClient.post<CancelReplaceBatchResponse>('/orders/cancel-replace/batch', body);
+  }
+
+  private async buildCancelReplaceReplacement(
+    params: CancelReplaceReplacementParams
+  ): Promise<CancelReplaceReplacementRequest> {
+    const userData = await this.ensureUserData();
+    let venue = this.marketFetcher.getVenue(params.marketSlug);
+    if (!venue) {
+      const market = await this.marketFetcher.getMarket(params.marketSlug);
+      if (!market.venue) {
+        throw new Error(`Market ${params.marketSlug} does not have venue information.`);
+      }
+      venue = market.venue;
+    }
+
+    const unsignedOrder = this.orderBuilder!.buildOrder(params);
+    const signature = await this.orderSigner.signOrder(unsignedOrder, {
+      ...this.signingConfig,
+      contractAddress: venue.exchange,
+    });
+    const postOnly =
+      params.orderType === OrderType.GTC && 'postOnly' in params ? params.postOnly : undefined;
+
+    return {
+      order: { ...unsignedOrder, signature },
+      orderType: params.orderType,
+      marketSlug: params.marketSlug,
+      ownerId: userData.userId,
+      ...(postOnly !== undefined ? { postOnly } : {}),
+      ...(params.clientOrderId !== undefined ? { clientOrderId: params.clientOrderId } : {}),
+      ...(params.timestamp !== undefined ? { timestamp: params.timestamp } : {}),
+      ...(params.recvWindow !== undefined ? { recvWindow: params.recvWindow } : {}),
+      ...(params.stpPolicy !== undefined ? { stpPolicy: params.stpPolicy } : {}),
+    };
   }
 
   /**
@@ -369,7 +433,10 @@ export class OrderClient {
         nonce: order.nonce,
         signature: order.signature,
         orderType: order.orderType,
-        price: order.price === undefined || order.price === null ? order.price : toFiniteNumber(order.price) ?? order.price,
+        price:
+          order.price === undefined || order.price === null
+            ? order.price
+            : (toFiniteNumber(order.price) ?? order.price),
         marketId: order.marketId,
       },
     };

--- a/src/types/delegated-orders.ts
+++ b/src/types/delegated-orders.ts
@@ -1,4 +1,13 @@
-import type { OrderArgs, OrderResponse, OrderType, SignatureType, Side } from './orders';
+import type {
+  CancelReplaceMode,
+  CancelReplaceTarget,
+  OrderArgs,
+  OrderResponse,
+  OrderType,
+  SignatureType,
+  Side,
+  StpPolicy,
+} from './orders';
 
 /**
  * Delegated-order creation parameters.
@@ -59,3 +68,49 @@ export interface CancelResponse {
  * @public
  */
 export type DelegatedOrderResponse = OrderResponse;
+
+export type DelegatedCancelReplaceReplacementParams = OrderArgs & {
+  marketSlug: string;
+  orderType: OrderType;
+  feeRateBps?: number;
+  clientOrderId?: string;
+  timestamp?: number;
+  recvWindow?: number;
+  stpPolicy?: StpPolicy;
+  onBehalfOf?: never;
+};
+
+export interface DelegatedCancelReplaceParams {
+  cancel: CancelReplaceTarget;
+  replacement: DelegatedCancelReplaceReplacementParams;
+  mode: CancelReplaceMode;
+  onBehalfOf: number;
+}
+
+export interface DelegatedCancelReplaceBatchParams {
+  operations: DelegatedCancelReplaceParams[];
+}
+
+export interface DelegatedCancelReplaceReplacementRequest {
+  order: DelegatedOrderSubmission;
+  orderType: OrderType;
+  marketSlug: string;
+  ownerId: number;
+  postOnly?: boolean;
+  clientOrderId?: string;
+  timestamp?: number;
+  recvWindow?: number;
+  stpPolicy?: StpPolicy;
+  onBehalfOf?: never;
+}
+
+export interface DelegatedCancelReplaceRequest {
+  cancel: CancelReplaceTarget;
+  replacement: DelegatedCancelReplaceReplacementRequest;
+  mode: CancelReplaceMode;
+  onBehalfOf: number;
+}
+
+export interface DelegatedCancelReplaceBatchRequest {
+  operations: DelegatedCancelReplaceRequest[];
+}

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -539,6 +539,10 @@ export interface Execution {
    */
   matched: boolean;
 
+  reason?: string;
+
+  stpMakerCancels?: string[];
+
   /**
    * Settlement state of the order.
    *
@@ -614,4 +618,94 @@ export interface OrderSigningConfig {
    * Contract address for verification (from venue.exchange)
    */
   contractAddress: string;
+}
+
+export enum CancelReplaceMode {
+  ALLOW_FAILURE = 'ALLOW_FAILURE',
+  STOP_ON_FAILURE = 'STOP_ON_FAILURE',
+}
+
+export type StpPolicy = 'cancel_maker' | 'cancel_taker' | 'cancel_both';
+
+export type CancelReplaceTarget =
+  | { orderId: string; clientOrderId?: never }
+  | { clientOrderId: string; orderId?: never };
+
+export interface CancelReplaceOrderSubmission extends Omit<SignedOrder, 'signatureType'> {
+  signatureType: SignatureType | 3;
+}
+
+export interface CancelReplaceReplacementRequest {
+  order: CancelReplaceOrderSubmission;
+  orderType: OrderType;
+  marketSlug: string;
+  ownerId: number;
+  postOnly?: boolean;
+  clientOrderId?: string;
+  timestamp?: number;
+  recvWindow?: number;
+  stpPolicy?: StpPolicy;
+  onBehalfOf?: never;
+}
+
+export interface CancelReplaceRequest {
+  cancel: CancelReplaceTarget;
+  replacement: CancelReplaceReplacementRequest;
+  mode: CancelReplaceMode;
+  onBehalfOf?: number;
+}
+
+export interface CancelReplaceBatchRequest {
+  operations: CancelReplaceRequest[];
+}
+
+export interface CancelReplaceError {
+  code: string;
+  message: string;
+}
+
+export type CancelReplaceCancelResult =
+  | { status: 'SUCCESS'; orderId: string; clientOrderId?: string; error?: never }
+  | {
+      status: 'FAILURE' | 'UNKNOWN';
+      error: CancelReplaceError;
+      orderId?: never;
+      clientOrderId?: never;
+    };
+
+export type CancelReplaceReplacementResult =
+  | { status: 'SUCCESS'; data: OrderResponse & { execution: Execution }; error?: never }
+  | { status: 'FAILURE' | 'UNKNOWN'; error: CancelReplaceError; data?: never }
+  | { status: 'NOT_ATTEMPTED'; data?: never; error?: never };
+
+export interface CancelReplaceResponse {
+  cancel: CancelReplaceCancelResult;
+  replacement: CancelReplaceReplacementResult;
+}
+
+export type CancelReplaceBatchResult = CancelReplaceResponse & { index: number };
+
+export interface CancelReplaceBatchResponse {
+  results: CancelReplaceBatchResult[];
+}
+
+export type CancelReplaceReplacementParams = OrderArgs & {
+  orderType: OrderType;
+  marketSlug: string;
+  clientOrderId?: string;
+  timestamp?: number;
+  recvWindow?: number;
+  stpPolicy?: StpPolicy;
+  onBehalfOf?: never;
+};
+
+export interface CancelReplaceParams {
+  cancel: CancelReplaceTarget;
+  replacement: CancelReplaceReplacementParams;
+  mode: CancelReplaceMode;
+  onBehalfOf?: never;
+}
+
+export interface CancelReplaceBatchParams {
+  operations: CancelReplaceParams[];
 }

--- a/tests/api/http-hmac.test.ts
+++ b/tests/api/http-hmac.test.ts
@@ -11,6 +11,36 @@ function normalizeHeaders(headers: any): Record<string, string> {
 }
 
 describe('HttpClient HMAC auth', () => {
+  it('signs and transmits the exact pre-serialized cancel-replace body', async () => {
+    const secret = Buffer.from('test-secret').toString('base64');
+    const client = new HttpClient({
+      baseURL: 'https://api.limitless.exchange',
+      hmacCredentials: { tokenId: 'token-1', secret },
+    });
+    let capturedConfig: any;
+    (client as any).client.defaults.adapter = async (config: any) => {
+      capturedConfig = config;
+      return { data: { ok: true }, status: 409, statusText: 'Conflict', headers: {}, config };
+    };
+    const body = '{"replacement":{"clientOrderId":"exact"},"cancel":{"orderId":"old"}}';
+
+    await client.post('/orders/cancel-replace', body, {
+      validateStatus: (status) => status === 409,
+    });
+
+    const headers = normalizeHeaders(capturedConfig.headers);
+    expect(capturedConfig.data).toBe(body);
+    expect(headers['lmts-signature']).toBe(
+      computeHMACSignature(
+        secret,
+        headers['lmts-timestamp'],
+        'POST',
+        '/orders/cancel-replace',
+        body
+      )
+    );
+  });
+
   it('injects HMAC headers and suppresses X-API-Key when HMAC is configured', async () => {
     const secret = Buffer.from('test-secret').toString('base64');
     const client = new HttpClient({

--- a/tests/delegated-orders/service.test.ts
+++ b/tests/delegated-orders/service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DelegatedOrderService } from '../../src/delegated-orders/service';
-import { OrderType, Side } from '../../src/types/orders';
+import { CancelReplaceMode, OrderType, Side } from '../../src/types/orders';
 import type { HttpClient } from '../../src/api/http';
 
 describe('DelegatedOrderService', () => {
@@ -45,7 +45,9 @@ describe('DelegatedOrderService', () => {
     const message = await service.cancelAllOnBehalfOf('market-slug', 326);
 
     expect(message).toBe('Orders canceled successfully');
-    expect((httpClient as any).delete).toHaveBeenCalledWith('/orders/all/market-slug?onBehalfOf=326');
+    expect((httpClient as any).delete).toHaveBeenCalledWith(
+      '/orders/all/market-slug?onBehalfOf=326'
+    );
   });
 
   it('omits postOnly for FAK delegated orders before submitting to the API', async () => {
@@ -72,5 +74,38 @@ describe('DelegatedOrderService', () => {
     const [, payload] = (httpClient as any).post.mock.calls[0];
     expect(payload.orderType).toBe(OrderType.FAK);
     expect(payload.postOnly).toBeUndefined();
+  });
+
+  it('builds delegated cancel-replace with operation-level onBehalfOf and no signature', async () => {
+    const httpClient = {
+      requireAuth: vi.fn(),
+      post: vi.fn().mockResolvedValue({ cancel: {}, replacement: {} }),
+    } as unknown as HttpClient;
+    const service = new DelegatedOrderService(httpClient);
+
+    await service.cancelReplace({
+      cancel: { orderId: 'old-order' },
+      mode: CancelReplaceMode.STOP_ON_FAILURE,
+      onBehalfOf: 326,
+      replacement: {
+        tokenId: '123',
+        side: Side.BUY,
+        price: 0.55,
+        size: 10,
+        orderType: OrderType.GTC,
+        marketSlug: 'market',
+        clientOrderId: 'replacement',
+      },
+    });
+
+    const [path, body, config] = (httpClient as any).post.mock.calls[0];
+    const payload = JSON.parse(body);
+    expect(path).toBe('/orders/cancel-replace');
+    expect(payload.onBehalfOf).toBe(326);
+    expect(payload.replacement.ownerId).toBe(326);
+    expect(payload.replacement.onBehalfOf).toBeUndefined();
+    expect(payload.replacement.order.signature).toBeUndefined();
+    expect(config.validateStatus(409)).toBe(true);
+    expect(config.validateStatus(400)).toBe(false);
   });
 });

--- a/tests/orders/client.test.ts
+++ b/tests/orders/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { OrderClient } from '../../src/orders/client';
-import { OrderType, Side } from '../../src/types/orders';
+import { CancelReplaceMode, OrderType, Side } from '../../src/types/orders';
 
 describe('OrderClient', () => {
   it('normalizes numeric-string createOrder fields for makerAmount, takerAmount, price, and safe salt', () => {
@@ -206,5 +206,80 @@ describe('OrderClient', () => {
     const [, payload] = httpClient.post.mock.calls[0];
     expect(payload.orderType).toBe(OrderType.FAK);
     expect(payload.postOnly).toBeUndefined();
+  });
+
+  it('builds and signs a direct cancel-replace replacement for the venue', async () => {
+    const httpClient = { post: vi.fn().mockResolvedValue({ cancel: {}, replacement: {} }) } as any;
+    const client = new OrderClient({
+      httpClient,
+      wallet: { address: '0x0000000000000000000000000000000000000001' } as any,
+    });
+    (client as any).cachedUserData = { userId: 42, feeRateBps: 300 };
+    (client as any).orderBuilder = { buildOrder: vi.fn().mockReturnValue({ tokenId: '123' }) };
+    (client as any).orderSigner = { signOrder: vi.fn().mockResolvedValue('0xsigned') };
+    (client as any).marketFetcher = {
+      getVenue: vi.fn().mockReturnValue({ exchange: '0x0000000000000000000000000000000000000002' }),
+    };
+
+    await client.cancelReplace({
+      cancel: { clientOrderId: 'old-client-id' },
+      mode: CancelReplaceMode.ALLOW_FAILURE,
+      replacement: {
+        tokenId: '123',
+        side: Side.BUY,
+        price: 0.5,
+        size: 2,
+        orderType: OrderType.GTC,
+        marketSlug: 'market',
+        clientOrderId: 'new-client-id',
+        timestamp: 1000,
+        recvWindow: 500,
+        stpPolicy: 'cancel_taker',
+        postOnly: true,
+      },
+    });
+
+    const [path, body, config] = httpClient.post.mock.calls[0];
+    const payload = JSON.parse(body);
+    expect(path).toBe('/orders/cancel-replace');
+    expect(payload.cancel).toEqual({ clientOrderId: 'old-client-id' });
+    expect(payload.replacement).toMatchObject({
+      ownerId: 42,
+      clientOrderId: 'new-client-id',
+      timestamp: 1000,
+      recvWindow: 500,
+      stpPolicy: 'cancel_taker',
+      postOnly: true,
+      order: { tokenId: '123', signature: '0xsigned' },
+    });
+    expect(payload.replacement.onBehalfOf).toBeUndefined();
+    expect((client as any).orderSigner.signOrder).toHaveBeenCalledWith(
+      { tokenId: '123' },
+      expect.objectContaining({ contractAddress: '0x0000000000000000000000000000000000000002' })
+    );
+    expect(config.validateStatus(409)).toBe(true);
+    expect(config.validateStatus(400)).toBe(false);
+  });
+
+  it('posts direct cancel-replace batches without imposing a local maximum', async () => {
+    const httpClient = { post: vi.fn().mockResolvedValue({ results: [] }) } as any;
+    const client = new OrderClient({ httpClient, wallet: { address: '0x1' } as any });
+    (client as any).buildCancelReplaceReplacement = vi.fn().mockResolvedValue({ order: {} });
+    const operation = {
+      cancel: { orderId: 'old' },
+      mode: CancelReplaceMode.STOP_ON_FAILURE,
+      replacement: {
+        tokenId: '1',
+        side: Side.BUY,
+        makerAmount: 1,
+        orderType: OrderType.FOK,
+        marketSlug: 'm',
+      },
+    } as const;
+
+    await client.cancelReplaceBatch({ operations: Array.from({ length: 5 }, () => operation) });
+
+    expect(httpClient.post.mock.calls[0][0]).toBe('/orders/cancel-replace/batch');
+    expect(JSON.parse(httpClient.post.mock.calls[0][1]).operations).toHaveLength(5);
   });
 });


### PR DESCRIPTION
Adds single and batch cancel-replace support for direct and delegated order flows.

Includes coverage for request serialization and response handling.